### PR TITLE
ReactCSSTransitionGroup

### DIFF
--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,13 +1,16 @@
 import React, { Component } from 'react';
-//import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { translate } from 'react-i18next';
 import style from './style.styl';
 
+
 export default ({position, action}) => (
-    <div className={style.modal} data-position={position} onClick={action.apply}>
-        <div className={style.widget}>
-            <img src={"https://media.giphy.com/media/o0vwzuFwCGAFO/giphy.gif"} />
+    <ReactCSSTransitionGroup transitionName="modal" transitionEnterTimeout={500} transitionLeaveTimeout={300}>
+        <div className={style.modal} data-position={position} onClick={action.apply}>
+            <div className={style.widget}>
+                <img src={"https://media.giphy.com/media/o0vwzuFwCGAFO/giphy.gif"} />
+            </div>
+            <div className={style.overlay}></div>
         </div>
-        <div className={style.overlay}></div>
-    </div>
+    </ReactCSSTransitionGroup>
 )

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+//import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { translate } from 'react-i18next';
 import style from './style.styl';
 

--- a/src/components/modal/style.styl
+++ b/src/components/modal/style.styl
@@ -71,13 +71,13 @@
     display: block
     transition: all 0.2s ease;
 
-.modal-enter
+:global(.modal-enter)
     opacity: 0.01;
     &.modal-enter-active
         opacity: 1;
         transition: opacity 500ms ease-in;
 
-.modal-leave
+:global(.modal-leave)
     opacity: 1;
     &.modal-leave-active
       opacity: 0.01;

--- a/src/components/modal/style.styl
+++ b/src/components/modal/style.styl
@@ -28,9 +28,8 @@
         max-height: 320px
         box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
         text-align: center
-        opacity:0.75
-        transform: translate(0, 250px)
-        transition: all 0.3s ease;
+        transition: all 0.3s ease
+
 
         /* Remove this */
         img
@@ -71,3 +70,15 @@
     z-index:0
     display: block
     transition: all 0.2s ease;
+
+.modal-enter
+    opacity: 0.01;
+    &.modal-enter-active
+        opacity: 1;
+        transition: opacity 500ms ease-in;
+
+.modal-leave
+    opacity: 1;
+    &.modal-leave-active
+      opacity: 0.01;
+      transition: opacity 300ms ease-in;


### PR DESCRIPTION
## Implement ReactCSSTransitionGroup

I get this error on **close-modal**:

`removeComponentAsRefFrom(...):  Only a ReactOwner can have refs`
> You might be removing a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).