### PR TITLE
Fix butter-component-builder installation bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/buttercomponents/butter-component-settings",
   "devDependencies": {
-    "butter-component-builder": "https://github.com/buttercomponents/butter-component-builder"
+    "butter-component-builder": "git+https://github.com/buttercomponents/butter-component-builder"
   },
   "dependencies": {
     "butter-action-types": "git+https://github.com/buttercomponents/butter-action-types.git",


### PR DESCRIPTION
I know this is weird, but this actually allow me to use `npm install`, 
I'm not sure if this is because I'm using Windows?

Whats the difference between this?
- https://github.com/buttercomponents/butter-component-builder
- git+https://github.com/buttercomponents/butter-component-builder